### PR TITLE
Reusing current user's Windows credentials

### DIFF
--- a/Ior/Core/IorClient.cs
+++ b/Ior/Core/IorClient.cs
@@ -47,7 +47,8 @@ namespace Swensen.Ior.Core {
 
             var handler = new HttpClientHandler {
                 AllowAutoRedirect = followRedirects,
-                UseCookies = hasCookies
+                UseCookies = hasCookies,
+				UseDefaultCredentials = true
             };
 
             if (!proxyServer.IsBlank()) {


### PR DESCRIPTION
Having the program connect to the server with current user's credentials is convenient when accessing services that are secured by Windows auth (NTLM or Kerberos). In my specific case, it's Microsoft TFS's REST API.